### PR TITLE
feature: Add GenresRepository

### DIFF
--- a/Movies/Movies/Data/DTO'S/GenreResponseDTO.swift
+++ b/Movies/Movies/Data/DTO'S/GenreResponseDTO.swift
@@ -1,0 +1,18 @@
+//
+//  GenreResponseDTO.swift
+//  Movies
+//
+//  Created by Carlos Molina Sáenz on 18/03/25.
+//
+
+
+import Foundation
+
+struct GenreResponseDTO: Codable {
+    let genres: [GenreDTO]
+}
+
+struct GenreDTO: Codable {
+    let id: Int
+    let name: String
+}

--- a/Movies/Movies/Data/Repositories/Protocol/GenresRepository.swift
+++ b/Movies/Movies/Data/Repositories/Protocol/GenresRepository.swift
@@ -1,0 +1,15 @@
+//
+//  RemoteGenresRepository.swift
+//  Movies
+//
+//  Created by Carlos Molina Sáenz on 18/03/25.
+//
+
+
+import Combine
+import Foundation
+
+/// sourcery: AutoMockable
+protocol GenresRepository {
+    func fetch() -> AnyPublisher<GenreResponseDTO, MoviesAppError>
+}

--- a/Movies/Movies/Data/Repositories/Protocol/MoviesRepository.swift
+++ b/Movies/Movies/Data/Repositories/Protocol/MoviesRepository.swift
@@ -10,6 +10,6 @@ import Combine
 import Foundation
 
 /// sourcery: AutoMockable
-protocol RemoteMoviesRepository {
+protocol MoviesRepository {
     func fetch(page: Int) -> AnyPublisher<MovieResponseDTO, MoviesAppError>
 }

--- a/Movies/Movies/Data/Repositories/RemoteGenresRepositoryImpl.swift
+++ b/Movies/Movies/Data/Repositories/RemoteGenresRepositoryImpl.swift
@@ -1,15 +1,14 @@
 //
-//  RemoteMoviesRepositoryImpl.swift
+//  RemoteGenresRepositoryImpl.swift
 //  Movies
 //
 //  Created by Carlos Molina Sáenz on 18/03/25.
 //
 
-
 import Combine
 import Foundation
 
-final class RemoteMoviesRepositoryImpl: MoviesRepository {
+final class RemoteGenreRepositoryImpl: GenresRepository {
 
     // MARK: - Private Properties
 
@@ -23,18 +22,14 @@ final class RemoteMoviesRepositoryImpl: MoviesRepository {
 
     // MARK: - Internal Methods
 
-    func fetch(page: Int) -> AnyPublisher<MovieResponseDTO, MoviesAppError> {
+    func fetch() -> AnyPublisher<GenreResponseDTO, MoviesAppError> {
         let version: String = Bundle.main.object(forInfoDictionaryKey: "MOVIE_API_VERSION") as? String ?? ""
         var components = URLComponents()
         components.scheme = Bundle.main.object(forInfoDictionaryKey: "MOVIE_API_SCHEME") as? String ?? ""
         components.host = Bundle.main.object(forInfoDictionaryKey: "MOVIE_API_HOST") as? String ?? ""
-        components.path = "/\(version)/discover/movie"
+        components.path = "/\(version)/genre/movie/list"
         components.queryItems = [
-            URLQueryItem(name: "include_adult", value: "false"),
-            URLQueryItem(name: "include_video", value: "false"),
-            URLQueryItem(name: "language", value: "en-US"),
-            URLQueryItem(name: "page", value: "\(page)"),
-            URLQueryItem(name: "sort_by", value: "popularity.desc")
+            URLQueryItem(name: "language", value: "en-US")
         ]
 
 
@@ -46,7 +41,7 @@ final class RemoteMoviesRepositoryImpl: MoviesRepository {
         return networkProvider.fetch(from: url).tryMap {
             let decode = JSONDecoder()
             decode.keyDecodingStrategy = .convertFromSnakeCase
-            guard let response: MovieResponseDTO = try? decode.decode(MovieResponseDTO.self, from: $0)
+            guard let response: GenreResponseDTO = try? decode.decode(GenreResponseDTO.self, from: $0)
             else {
                 throw MoviesAppError.invalidFormat
             }

--- a/Movies/MoviesTests/Data/Repositories/RemoteGenresRepositoryImplTests.swift
+++ b/Movies/MoviesTests/Data/Repositories/RemoteGenresRepositoryImplTests.swift
@@ -1,0 +1,139 @@
+//
+//  RemoteGenresRepositoryImplTests.swift
+//  Movies
+//
+//  Created by Carlos Molina Sáenz on 18/03/25.
+//
+
+import Combine
+import Foundation
+import XCTest
+
+@testable import Movies
+
+final class RemoteGenresRepositoryImplTests: XCTestCase {
+    
+    // MARK: - Private Typealias
+    
+    private typealias SUT = RemoteGenreRepositoryImpl
+    
+    // MARK: - Private Properties
+    
+    private var sut: SUT!
+    private var mockNetworkProvider: NetworkProviderMock!
+    private var tasks: Set<AnyCancellable>!
+    
+    // MARK: - Lifecycle
+    
+    override func setUp() {
+        super.setUp()
+        
+        tasks = .init()
+        mockNetworkProvider = NetworkProviderMock()
+        sut = SUT(networkProvider: mockNetworkProvider)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        
+        sut = nil
+        mockNetworkProvider = nil
+        tasks = nil
+        
+    }
+    
+    // MARK: - Tests
+    
+    func test_fetch_shouldReturnValues() {
+        guard let asset = NSDataAsset(name: "GenresListResponse")
+        else {
+            XCTFail("Init Error")
+            return
+        }
+        
+        let expectation = XCTestExpectation(
+            description: "test_fetch_shouldReturnValues")
+        let publisher = Just(asset.data)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+        
+        mockNetworkProvider.fetchFromUrlURLAnyPublisherDataErrorReturnValue = publisher
+        
+        sut.fetch().sink {
+            switch $0 {
+            case .failure(let error):
+                XCTFail("Error: \(error.localizedDescription)")
+            case .finished:
+                break
+            }
+            expectation.fulfill()
+        } receiveValue: {
+            XCTAssertNotNil($0)
+            XCTAssertEqual($0.genres.count, 3)
+        }.store(in: &tasks)
+        
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockNetworkProvider.fetchFromUrlURLAnyPublisherDataErrorCallsCount, 1)
+        
+        tasks.removeAll()
+    }
+    
+    func test_fetch_whenErrorIsReceived_errorShouldNotBeNil() {
+        let expectation = XCTestExpectation(
+            description: "test_fetch_whenErrorIsReceived_errorShouldNotBeNil")
+        let publisher = Fail<Data, Error>(error: NSError(domain: "test.domain",
+                                                         code: -1))
+            .eraseToAnyPublisher()
+        
+        mockNetworkProvider.fetchFromUrlURLAnyPublisherDataErrorReturnValue = publisher
+
+        sut.fetch().sink {
+            switch $0 {
+            case .failure(let error):
+                XCTAssertNotNil(error)
+            case .finished:
+                break
+            }
+            expectation.fulfill()
+        } receiveValue: { _ in
+            XCTFail("Error was sent")
+        }.store(in: &tasks)
+        
+        wait(for: [expectation], timeout: 1.0)
+        
+        XCTAssertEqual(mockNetworkProvider.fetchFromUrlURLAnyPublisherDataErrorCallsCount, 1)
+        tasks.removeAll()
+    }
+    
+    func test_fetch_whenBadDataIsReceived_errorShouldNotBeNil() {
+        guard let data = "bad data".data(using: .utf8)
+        else {
+            XCTFail("Init Error")
+            return
+        }
+        
+        let expectation = XCTestExpectation(
+            description: "test_fetch_whenBadDataIsReceived_shouldNotBeNil")
+        let publisher = Just(data)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+        
+        mockNetworkProvider.fetchFromUrlURLAnyPublisherDataErrorReturnValue = publisher
+
+        sut.fetch().sink {
+            switch $0 {
+            case .failure(let error):
+                XCTAssertNotNil(error)
+            case .finished:
+                break
+            }
+            expectation.fulfill()
+        } receiveValue: { _ in
+            XCTFail("Bad Data was sent")
+        }.store(in: &tasks)
+        
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockNetworkProvider.fetchFromUrlURLAnyPublisherDataErrorCallsCount, 1)
+        tasks.removeAll()
+    }
+}

--- a/Movies/MoviesTests/Resources/MockResponses.xcassets/GenresListResponse.dataset/Contents.json
+++ b/Movies/MoviesTests/Resources/MockResponses.xcassets/GenresListResponse.dataset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "data" : [
+    {
+      "filename" : "response.json",
+      "idiom" : "universal",
+      "universal-type-identifier" : "public.json"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Movies/MoviesTests/Resources/MockResponses.xcassets/GenresListResponse.dataset/response.json
+++ b/Movies/MoviesTests/Resources/MockResponses.xcassets/GenresListResponse.dataset/response.json
@@ -1,0 +1,1 @@
+{"genres":[{"id":28,"name":"Action"},{"id":12,"name":"Adventure"},{"id":16,"name":"Animation"}]}


### PR DESCRIPTION
---
### Pull Request Description

This PR adds the RemoteGenreRepositoryImpl, which is responsible for fetching movie genres from the TheMovieDB API. It integrates with the NetworkProvider to retrieve data and maps the response to a GenreResponseDTO.

### Type of Change

<!-- Please delete options that are not relevant. -->

- [X] New feature
- [X] Enhancement

### Checklist

- [X] I have read the project's documentation.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

### Proposed Changes

Proposed Changes

- Implemented RemoteGenreRepositoryImpl
- Fetches the list of genres from TheMovieDB API.
- Uses NetworkProvider to perform network requests.
- Decodes API responses into GenreResponseDTO.


### How Have the Changes Been Tested?

The repository has been tested using unit tests with a mock NetworkProvider:
	1.	Valid Response Test: Ensures that the repository correctly fetches and decodes a valid response.
	2.	Network Failure Test: Simulates a network error and checks that it propagates correctly.
	3.	Invalid Data Test: Tests how the repository handles a response with an incorrect format.

All tests run successfully with the expected results.

---