### PR TITLE
feature: Add FetchMoviesUseCase

### DIFF
--- a/Movies/Movies/Domain/UseCases/FetchMoviesUseCaseImpl.swift
+++ b/Movies/Movies/Domain/UseCases/FetchMoviesUseCaseImpl.swift
@@ -1,0 +1,61 @@
+//
+//  FetchMoviesUseCase.swift
+//  Movies
+//
+//  Created by Carlos Molina Sáenz on 18/03/25.
+//
+
+import Foundation
+import Combine
+
+final class FetchMoviesUseCaseImpl: FetchMoviesUseCase {
+    
+    // MARK: - Private Properties
+
+    private let movieRepository: MoviesRepository
+    private let genreRepository: GenresRepository
+
+    // MARK: - Initialization
+
+    init(movieRepository: MoviesRepository, genreRepository: GenresRepository) {
+        self.movieRepository = movieRepository
+        self.genreRepository = genreRepository
+    }
+
+    // MARK: - Internal Methods
+
+    func execute(page: Int) -> AnyPublisher<[MovieModel], MoviesAppError> {
+        let moviesPublisher = movieRepository.fetch(page: page)
+        let genresPublisher = genreRepository.fetch()
+            .catch { _ in
+                Just(GenreResponseDTO(genres: []))
+                .setFailureType(to: MoviesAppError.self)
+            }
+            .eraseToAnyPublisher()
+
+        return Publishers.CombineLatest(moviesPublisher, genresPublisher)
+            .map { moviesDTO, genreResponseDTO in
+                let genresDictionary = Dictionary(uniqueKeysWithValues: genreResponseDTO.genres.map { ($0.id, $0) })
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd"
+                
+                return moviesDTO.results.map {
+                    MovieModel(
+                        id: $0.id,
+                        name: $0.title,
+                        overview: $0.overview,
+                        posterURL: URL(string: $0.posterPath ?? ""),
+                        releaseDate: formatter.date(from: $0.releaseDate),
+                        genres: $0.genreIds.compactMap {
+                            guard
+                                let genreDTO = genresDictionary[$0]
+                            else { return nil }
+                            
+                            return GenreModel(id: genreDTO.id, name: genreDTO.name)
+                        }
+                    )
+                }
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Movies/Movies/Domain/UseCases/Protocol/FetchMoviesUseCase.swift
+++ b/Movies/Movies/Domain/UseCases/Protocol/FetchMoviesUseCase.swift
@@ -1,0 +1,14 @@
+//
+//  FetchMoviesUseCase.swift
+//  Movies
+//
+//  Created by Carlos Molina Sáenz on 18/03/25.
+//
+
+import Combine
+import Foundation
+
+/// sourcery: AutoMockable
+protocol FetchMoviesUseCase {
+    func execute(page: Int) -> AnyPublisher<[MovieModel], MoviesAppError>
+}

--- a/Movies/MoviesTests/Domain/UseCases/FetchMoviesUseCaseImplTests.swift
+++ b/Movies/MoviesTests/Domain/UseCases/FetchMoviesUseCaseImplTests.swift
@@ -1,0 +1,185 @@
+//
+//  FetchMoviesUseCaseTests.swift
+//  MoviesTests
+//
+//  Created by Carlos Molina Sáenz on 18/03/25.
+//
+
+import Combine
+import XCTest
+@testable import Movies
+
+final class FetchMoviesUseCaseImplTests: XCTestCase {
+    
+    // MARK: - Private Typealias
+    
+    private typealias SUT = FetchMoviesUseCaseImpl
+    
+    // MARK: - Private Properties
+    
+    private var sut: SUT!
+    private var mockMoviesRepository: MoviesRepositoryMock!
+    private var mockGenresRepository: GenresRepositoryMock!
+    private var tasks: Set<AnyCancellable>!
+    
+    // MARK: - Lifecycle
+    
+    override func setUp() {
+        super.setUp()
+        
+        tasks = .init()
+        mockMoviesRepository = MoviesRepositoryMock()
+        mockGenresRepository = GenresRepositoryMock()
+        
+        sut = SUT(movieRepository: mockMoviesRepository,
+                  genreRepository: mockGenresRepository)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        
+        sut = nil
+        mockMoviesRepository = nil
+        mockGenresRepository = nil
+        tasks = nil
+    }
+    
+    // MARK: - Tests
+    
+    func test_execute_shouldReturnMoviesWithGenres() throws {
+        guard let asset = NSDataAsset(name: "MoviesListResponse"),
+              let genreAsset = NSDataAsset(name: "GenresListResponse")
+        else {
+            XCTFail("Init Error")
+            return
+        }
+        
+        let decode = JSONDecoder()
+        decode.keyDecodingStrategy = .convertFromSnakeCase
+        
+        let movieResponse = try decode.decode(MovieResponseDTO.self,
+                                              from: asset.data)
+        let genreResponse = try decode.decode(GenreResponseDTO.self,
+                                              from: genreAsset.data)
+        
+        let moviesPublisher = Just(movieResponse)
+            .setFailureType(to: MoviesAppError.self)
+            .eraseToAnyPublisher()
+        let genrePublisher = Just(genreResponse)
+            .setFailureType(to: MoviesAppError.self)
+            .eraseToAnyPublisher()
+        
+        mockMoviesRepository.fetchPageIntAnyPublisherMovieResponseDTOMoviesAppErrorReturnValue = moviesPublisher
+        mockGenresRepository.fetchAnyPublisherGenreResponseDTOMoviesAppErrorReturnValue = genrePublisher
+        
+        let expectation = XCTestExpectation(
+            description: "test_execute_shouldReturnMoviesWithGenres")
+        
+        sut.execute(page: 2)
+            .sink {
+                switch $0 {
+                case .failure(let error):
+                    XCTFail("Error: \(error.localizedDescription)")
+                case .finished:
+                    break
+                }
+                expectation.fulfill()
+            } receiveValue: { list in
+                XCTAssertEqual(list.count, 3)
+            }.store(in: &tasks)
+        
+        wait(for: [expectation], timeout: 1.0)
+        
+        XCTAssertEqual(mockMoviesRepository.fetchPageIntAnyPublisherMovieResponseDTOMoviesAppErrorReceivedPage, 2)
+        XCTAssertEqual(mockMoviesRepository.fetchPageIntAnyPublisherMovieResponseDTOMoviesAppErrorCallsCount, 1)
+        XCTAssertEqual(mockGenresRepository.fetchAnyPublisherGenreResponseDTOMoviesAppErrorCallsCount, 1)
+    }
+    
+    func test_execute_whenMoviesRepositoryFails_shouldReturnError() throws {
+        guard let asset = NSDataAsset(name: "GenresListResponse")
+        else {
+            XCTFail("Init Error")
+            return
+        }
+        
+        let decode = JSONDecoder()
+        decode.keyDecodingStrategy = .convertFromSnakeCase
+        let genreResponse = try decode.decode(GenreResponseDTO.self,
+                                              from: asset.data)
+        let genrePublisher = Just(genreResponse)
+            .setFailureType(to: MoviesAppError.self)
+            .eraseToAnyPublisher()
+        
+        let errorMovies = MoviesAppError.networkError(NSError(domain: "test.error", code: -1))
+        let moviesPublisher = Fail<MovieResponseDTO, MoviesAppError>(error: errorMovies).eraseToAnyPublisher()
+        
+        mockMoviesRepository.fetchPageIntAnyPublisherMovieResponseDTOMoviesAppErrorReturnValue = moviesPublisher
+        mockGenresRepository.fetchAnyPublisherGenreResponseDTOMoviesAppErrorReturnValue = genrePublisher
+
+        let expectation = XCTestExpectation(description: "Fetch movies fails")
+        
+        sut.execute(page: 1)
+            .sink {
+                switch $0 {
+                case .failure(let error):
+                    XCTAssertEqual(error.localizedDescription, errorMovies.localizedDescription)
+                case .finished:
+                    break
+                }
+                expectation.fulfill()
+            } receiveValue: { list in
+                XCTFail("Movies should not have been fetched")
+            }.store(in: &tasks)
+                   
+        wait(for: [expectation], timeout: 1.0)
+        
+        XCTAssertEqual(mockMoviesRepository.fetchPageIntAnyPublisherMovieResponseDTOMoviesAppErrorReceivedPage, 1)
+        XCTAssertEqual(mockMoviesRepository.fetchPageIntAnyPublisherMovieResponseDTOMoviesAppErrorCallsCount, 1)
+        XCTAssertEqual(mockGenresRepository.fetchAnyPublisherGenreResponseDTOMoviesAppErrorCallsCount, 1)
+    }
+    
+    func test_execute_whenGenresRepositoryFails_shouldReturnMoviesWithEmptyGenres() throws {
+        guard let asset = NSDataAsset(name: "MoviesListResponse")
+        else {
+            XCTFail("Init Error")
+            return
+        }
+        
+        let decode = JSONDecoder()
+        decode.keyDecodingStrategy = .convertFromSnakeCase
+        let movieResponse = try decode.decode(MovieResponseDTO.self,
+                                              from: asset.data)
+        let moviesPublisher = Just(movieResponse)
+            .setFailureType(to: MoviesAppError.self)
+            .eraseToAnyPublisher()
+        let error = MoviesAppError.networkError(NSError(domain: "test.error", code: -1))
+        let genresErrorPublisher = Fail<GenreResponseDTO, MoviesAppError>(error: error).eraseToAnyPublisher()
+
+        mockMoviesRepository.fetchPageIntAnyPublisherMovieResponseDTOMoviesAppErrorReturnValue = moviesPublisher
+        mockGenresRepository.fetchAnyPublisherGenreResponseDTOMoviesAppErrorReturnValue = genresErrorPublisher
+
+        
+        let expectation = XCTestExpectation(description: "Fetch movies but genres fail")
+        
+        sut.execute(page: 1)
+            .sink {
+                switch $0 {
+                case .failure(_):
+                    XCTFail("Movies should have been fetched even if genres fail")
+                case .finished:
+                    break
+                }
+                expectation.fulfill()
+            } receiveValue: { list in
+                XCTAssertEqual(list.count, 3)
+                XCTAssertEqual(list.first?.genres.count, 0)
+            }.store(in: &tasks)
+
+        
+        wait(for: [expectation], timeout: 1.0)
+        
+        XCTAssertEqual(mockMoviesRepository.fetchPageIntAnyPublisherMovieResponseDTOMoviesAppErrorReceivedPage, 1)
+        XCTAssertEqual(mockMoviesRepository.fetchPageIntAnyPublisherMovieResponseDTOMoviesAppErrorCallsCount, 1)
+        XCTAssertEqual(mockGenresRepository.fetchAnyPublisherGenreResponseDTOMoviesAppErrorCallsCount, 1)
+    }
+}


### PR DESCRIPTION
---
### Pull Request Description

This PR introduces the FetchMoviesUseCaseImpl class, which is responsible for fetching movies from the repository and enriching them with genre information. The implementation ensures that even if the genres request fails, movies are still returned with an empty genres list, preventing data loss and improving the user experience.

### Type of Change

<!-- Please delete options that are not relevant. -->

- [X] New feature
- [X] Enhancement

### Checklist

- [x] I have read the project's documentation.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

### Proposed Changes

- Added FetchMoviesUseCaseImpl to handle the fetching of movies and genres.
- Implemented error handling in genresPublisher to ensure that movie data is returned even if fetching genres fails.
- Used Publishers.CombineLatest to merge movie and genre data before mapping it into MovieModel.

### How Have the Changes Been Tested?

Unit tests were created to verify the correct transformation of data.

- Successful movie and genre fetching.
- Failing genre fetch, ensuring movies are still returned.
- Failing movies fetch.

### Additional Context

This implementation ensures better fault tolerance in case of network issues affecting genre retrieval.

---